### PR TITLE
Fix gulp build when used with production profile

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -162,7 +162,7 @@ gulp.task('build', ['copy'], function () {
 });
 
 gulp.task('usemin', ['images', 'styles'], function() {
-    return gulp.src(yeoman.app + '*.html').
+    return gulp.src(yeoman.app + '**/*.html').
         pipe(usemin({
             css: [
                 prefix.apply(),


### PR DESCRIPTION
In particular, not all view files were being bundled in the resulting production WAR

Fixes #994
